### PR TITLE
なおした

### DIFF
--- a/blog/styles/globals.css
+++ b/blog/styles/globals.css
@@ -18,7 +18,7 @@
   --small-heading3: calc(var(--small-heading2) * 0.86);
 
   /* スペース */
-  --space-xs: clamp(1.25rem, 1rem +0.98vw, 1.875rem);
+  --space-xs: clamp(1.25rem, 1rem + 0.98vw, 1.875rem);
   --space-sm: calc(var(--space-xs) * 1.5);
   --space-md: calc(var(--space-xs) * 2);
   --space-lg: calc(var(--space-xs) * 3);


### PR DESCRIPTION
- https://www.w3.org/TR/css-values-3/#calc-syntax

> In addition, [white space](https://www.w3.org/TR/css-syntax/#whitespace) is required on both sides of the [+](https://www.w3.org/TR/selectors4/#selectordef-adjacent) and - operators. (The [*](https://www.w3.org/TR/css3-selectors/#x) and / operaters can be used without white space around them.)